### PR TITLE
Handle older dbus headers where DBUS_MESSAGE_ITER_INIT_CLOSED is undefined

### DIFF
--- a/src-ble/linux/simpledbus/base/Message.cpp
+++ b/src-ble/linux/simpledbus/base/Message.cpp
@@ -69,7 +69,11 @@ void Message::_invalidate() {
     this->_iter_initialized = false;
     this->_is_extracted = false;
     this->_extracted = Holder();
+    #ifdef DBUS_MESSAGE_ITER_INIT_CLOSED
     this->_iter = DBUS_MESSAGE_ITER_INIT_CLOSED;
+    #else
+    this->_iter = DBusMessageIter();
+    #endif
 }
 
 void Message::_safe_delete() {


### PR DESCRIPTION
fixes #2

I haven't reviewed your project to match its code style, I'm afraid.  I'm just trying to get it up and running, as a way to work on cross-platform bluetooth.