### PR TITLE
tester: check device index to prevent user-initiated segfault

### DIFF
--- a/src-ble-test/main.cpp
+++ b/src-ble-test/main.cpp
@@ -65,13 +65,21 @@ int main() {
     ble.setup(ble_events);
     ble.scan_timeout(SCAN_TIMEOUT_MS);
 
+    std::cout << devices.size() << " devices found:" << std::endl;
+
     for (int i = 0; i < devices.size(); i++) {
         std::cout << "  " << i << ": " << devices[i].name << " (" << devices[i].address << ")" << std::endl;
     }
 
     std::cout << "Type index of device to connect to: ";
+
     int device;
     std::cin >> device;
+
+    if (device >= devices.size()) {
+        std::cout << "Device index out of range." << std::endl;
+        exit(-1);
+    }
     
     ble.connect(devices[device].address);
 


### PR DESCRIPTION
This came up because the dbus scan is not actually working on my system, returning no devices, and I thought I had to guess the device index blindly.