### PR TITLE
provide for devices without names

### DIFF
--- a/src-ble/linux/NativeBleInternal.cpp
+++ b/src-ble/linux/NativeBleInternal.cpp
@@ -30,17 +30,13 @@ void NativeBleInternal::scan_start() {
         DeviceDescriptor descriptor;
         descriptor.address = dev->get_address();
         descriptor.name = dev->get_name();
-        if (dev->get_name() != "") {
-            callback_holder.callback_on_scan_found(descriptor);
-        }
+        callback_holder.callback_on_scan_found(descriptor);
     }
     adapter->OnDeviceFound = [&](std::string address, std::string name) {
         DeviceDescriptor descriptor;
         descriptor.address = address;
         descriptor.name = name;
-        if (name != "") {
-            callback_holder.callback_on_scan_found(descriptor);
-        }
+        callback_holder.callback_on_scan_found(descriptor);
     };
     adapter->discovery_filter_transport_set("le");
     adapter->StartDiscovery();

--- a/src-ble/linux/bluezdbus/interfaces/Device1.cpp
+++ b/src-ble/linux/bluezdbus/interfaces/Device1.cpp
@@ -13,7 +13,7 @@ void Device1::add_option(std::string option_name, SimpleDBus::Holder value) {
 
     if (option_name == "Address") {
         _address = value.get_string();
-    } else if (option_name == "Name") {
+    } else if (option_name == "Alias") {
         _name = value.get_string();
     } else if (option_name == "Connected") {
         _connected = value.get_boolean();


### PR DESCRIPTION
Additionally, the bluez dbus documentation recommends use of Alias over Name.