### PR TITLE
change delete[] to free for valgrind

### DIFF
--- a/src-ble/linux/simpledbus/base/Logger.cpp
+++ b/src-ble/linux/simpledbus/base/Logger.cpp
@@ -64,7 +64,7 @@ std::string Logger::string_format(const char* format, va_list vlist) {
 
     if (result >= 0) {
         text = std::string(text_buffer);
-        delete[] text_buffer;
+        free(text_buffer);
     } else {
         // An error has happened with vasprintf.
         printf("Error during message generation. Format was: '%s'", format);


### PR DESCRIPTION
valgrind reports a 'Mismatched free() / delete / delete []' because an array is alloc'd with malloc and free'd with delete [].

changing this aids valgrind output, improving debuggability.