### PR TITLE
wait for StartDiscovery to complete before returning

### DIFF
--- a/src-ble/linux/NativeBleInternal.cpp
+++ b/src-ble/linux/NativeBleInternal.cpp
@@ -1,4 +1,5 @@
 #include "NativeBleInternal.h"
+#include <future>
 #include <sstream>
 
 using namespace NativeBLE;
@@ -43,7 +44,12 @@ void NativeBleInternal::scan_start() {
         }
     };
     adapter->discovery_filter_transport_set("le");
+    std::promise<void> discovery_started;
+    adapter->OnDiscoveryStarted = [&]() {
+        discovery_started.set_value();
+    };
     adapter->StartDiscovery();
+    discovery_started.get_future().get();
     callback_holder.callback_on_scan_start();
 }
 


### PR DESCRIPTION
this prevents the user from stopping discovery before it is started, which results in discovery staying active [forever] after it starts.